### PR TITLE
fix: use dot notation for filter properties to comply with Claude API schema requirements

### DIFF
--- a/src/tools/base-tool.ts
+++ b/src/tools/base-tool.ts
@@ -169,12 +169,19 @@ export abstract class BaseTool {
     for (const [key, value] of Object.entries(queryParams || {})) {
       if (value === undefined || value === null) continue;
 
+      // Transform dot notation back to bracket notation for SE Ranking API
+      // filter.volume.from -> filter[volume][from]
+      // filter.keyword_count.from -> filter[keyword_count][from]
+      // filter.multi_keyword_excluded -> filter[multi_keyword_excluded]
+      const apiKey = key.replace(/^filter\.([^.]+)\.([^.]+)$/, 'filter[$1][$2]')
+                        .replace(/^filter\.([^.]+)$/, 'filter[$1]');
+
       if (Array.isArray(value)) {
         for (const v of value) {
-          if (v !== undefined && v !== null) query.append(key, String(v));
+          if (v !== undefined && v !== null) query.append(apiKey, String(v));
         }
       } else {
-        query.append(key, String(value));
+        query.append(apiKey, String(value));
       }
     }
 
@@ -187,12 +194,19 @@ export abstract class BaseTool {
     for (const [key, value] of Object.entries(formParams || {})) {
       if (value === undefined || value === null) continue;
 
+      // Transform dot notation back to bracket notation for SE Ranking API
+      // filter.volume.from -> filter[volume][from]
+      // filter.keyword_count.from -> filter[keyword_count][from]
+      // filter.multi_keyword_excluded -> filter[multi_keyword_excluded]
+      const apiKey = key.replace(/^filter\.([^.]+)\.([^.]+)$/, 'filter[$1][$2]')
+                        .replace(/^filter\.([^.]+)$/, 'filter[$1]');
+
       if (Array.isArray(value)) {
         for (const v of value) {
-          if (v !== undefined && v !== null) form.append(key, String(v));
+          if (v !== undefined && v !== null) form.append(apiKey, String(v));
         }
       } else {
-        form.append(key, String(value));
+        form.append(apiKey, String(value));
       }
     }
 

--- a/src/tools/domain/domain-keywords.ts
+++ b/src/tools/domain/domain-keywords.ts
@@ -89,19 +89,19 @@ export class DomainKeywords extends BaseTool {
             .describe(
               'Filters keywords based on changes in their ranking positions compared to the previous period.',
             ),
-          'filter[volume][from]': z
+          'filter.volume.from': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Specifies the minimum monthly search volume for keywords to be included.'),
-          'filter[volume][to]': z
+          'filter.volume.to': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Specifies the maximum monthly search volume for keywords to be included.'),
-          'filter[difficulty][from]': z
+          'filter.difficulty.from': z
             .number()
             .int()
             .min(0)
@@ -109,7 +109,7 @@ export class DomainKeywords extends BaseTool {
             .describe(
               'Specifies the minimum keyword difficulty score (typically 0-100) for keywords to be included.',
             ),
-          'filter[difficulty][to]': z
+          'filter.difficulty.to': z
             .number()
             .int()
             .min(0)
@@ -117,26 +117,26 @@ export class DomainKeywords extends BaseTool {
             .describe(
               'Specifies the maximum keyword difficulty score for keywords to be included.',
             ),
-          'filter[keyword_count][from]': z
+          'filter.keyword_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Specifies the minimum number of words in a keyword phrase.'),
-          'filter[keyword_count][to]': z
+          'filter.keyword_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Specifies the maximum number of words in a keyword phrase.'),
-          'filter[intents]': z
+          'filter.intents': z
             .string()
             .optional()
             .refine((val?: string | null) => this.isValidCommaSeparatedList(INTENTS, val), {
               message: 'filter[intents] must be a comma-separated list of supported intents',
             })
             .describe('A comma-separated list of search intent codes to filter keywords.'),
-          'filter[competition][from]': z
+          'filter.competition.from': z
             .number()
             .min(0)
             .max(100)
@@ -144,51 +144,51 @@ export class DomainKeywords extends BaseTool {
             .describe(
               'Specifies the minimum competition score (typically 0-1 or 0-100, depending on the metric scale) for keywords.',
             ),
-          'filter[competition][to]': z
+          'filter.competition.to': z
             .number()
             .optional()
             .describe('Specifies the maximum competition score for keywords.'),
-          'filter[cpc][from]': z
+          'filter.cpc.from': z
             .number()
             .min(0)
             .optional()
             .describe('Specifies the minimum Cost Per Click (CPC) value for keywords.'),
-          'filter[cpc][to]': z
+          'filter.cpc.to': z
             .number()
             .min(0)
             .optional()
             .describe('Specifies the maximum Cost Per Click (CPC) value for keywords.'),
-          'filter[traffic][from]': z
+          'filter.traffic.from': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Specifies the minimum estimated monthly traffic for keywords.'),
-          'filter[traffic][to]': z
+          'filter.traffic.to': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Specifies the maximum estimated monthly traffic for keywords.'),
-          'filter[position][from]': z
+          'filter.position.from': z
             .number()
             .int()
             .positive()
             .optional()
             .describe('Specifies the minimum ranking position for keywords.'),
-          'filter[position][to]': z
+          'filter.position.to': z
             .number()
             .int()
             .positive()
             .optional()
             .describe('Specifies the maximum ranking position for keywords.'),
-          'filter[characters_count][from]': z
+          'filter.characters_count.from': z
             .number()
             .int()
             .positive()
             .optional()
             .describe('Specifies the minimum character length for keyword phrases.'),
-          'filter[characters_count][to]': z
+          'filter.characters_count.to': z
             .number()
             .int()
             .positive()

--- a/src/tools/keywords/keywords-longtail.ts
+++ b/src/tools/keywords/keywords-longtail.ts
@@ -36,71 +36,71 @@ export class KeywordsLongtail extends BaseTool {
             .enum(['asc', 'desc'])
             .optional()
             .describe('The order of sorting for the sort field.'),
-          'filter[volume][from]': z
+          'filter.volume.from': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Minimum monthly search volume.'),
-          'filter[volume][to]': z
+          'filter.volume.to': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Maximum monthly search volume.'),
-          'filter[difficulty][from]': z
+          'filter.difficulty.from': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Minimum keyword difficulty score (0-100).'),
-          'filter[difficulty][to]': z
+          'filter.difficulty.to': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Maximum keyword difficulty score (0-100).'),
-          'filter[cpc][from]': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
-          'filter[cpc][to]': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
-          'filter[competition][from]': z
+          'filter.cpc.from': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
+          'filter.cpc.to': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
+          'filter.competition.from': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Minimum competition score (0.0-1.0).'),
-          'filter[competition][to]': z
+          'filter.competition.to': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Maximum competition score (0.0-1.0).'),
-          'filter[keyword_count][from]': z
+          'filter.keyword_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum number of words in the keyword.'),
-          'filter[keyword_count][to]': z
+          'filter.keyword_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum number of words in the keyword.'),
-          'filter[characters_count][from]': z
+          'filter.characters_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum character length of the keyword.'),
-          'filter[characters_count][to]': z
+          'filter.characters_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum character length of the keyword.'),
-          'filter[serp_features]': z
+          'filter.serp_features': z
             .string()
             .optional()
             .refine(

--- a/src/tools/keywords/keywords-questions.ts
+++ b/src/tools/keywords/keywords-questions.ts
@@ -49,71 +49,71 @@ export class KeywordsQuestions extends BaseTool {
             .optional()
             .default(false)
             .describe('Whether to include historical search volume trend data in the response.'),
-          'filter[volume][from]': z
+          'filter.volume.from': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Minimum monthly search volume.'),
-          'filter[volume][to]': z
+          'filter.volume.to': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Maximum monthly search volume.'),
-          'filter[difficulty][from]': z
+          'filter.difficulty.from': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Minimum keyword difficulty score (0-100).'),
-          'filter[difficulty][to]': z
+          'filter.difficulty.to': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Maximum keyword difficulty score (0-100).'),
-          'filter[cpc][from]': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
-          'filter[cpc][to]': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
-          'filter[competition][from]': z
+          'filter.cpc.from': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
+          'filter.cpc.to': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
+          'filter.competition.from': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Minimum competition score (0.0-1.0).'),
-          'filter[competition][to]': z
+          'filter.competition.to': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Maximum competition score (0.0-1.0).'),
-          'filter[keyword_count][from]': z
+          'filter.keyword_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum number of words in the keyword.'),
-          'filter[keyword_count][to]': z
+          'filter.keyword_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum number of words in the keyword.'),
-          'filter[characters_count][from]': z
+          'filter.characters_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum character length of the keyword.'),
-          'filter[characters_count][to]': z
+          'filter.characters_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum character length of the keyword.'),
-          'filter[serp_features]': z
+          'filter.serp_features': z
             .string()
             .optional()
             .refine(

--- a/src/tools/keywords/keywords-related.ts
+++ b/src/tools/keywords/keywords-related.ts
@@ -49,71 +49,71 @@ export class KeywordsRelated extends BaseTool {
             .optional()
             .default(false)
             .describe('Whether to include historical search volume trend data in the response.'),
-          'filter[volume][from]': z
+          'filter.volume.from': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Minimum monthly search volume.'),
-          'filter[volume][to]': z
+          'filter.volume.to': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Maximum monthly search volume.'),
-          'filter[difficulty][from]': z
+          'filter.difficulty.from': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Minimum keyword difficulty score (0-100).'),
-          'filter[difficulty][to]': z
+          'filter.difficulty.to': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Maximum keyword difficulty score (0-100).'),
-          'filter[cpc][from]': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
-          'filter[cpc][to]': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
-          'filter[competition][from]': z
+          'filter.cpc.from': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
+          'filter.cpc.to': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
+          'filter.competition.from': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Minimum competition score (0.0-1.0).'),
-          'filter[competition][to]': z
+          'filter.competition.to': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Maximum competition score (0.0-1.0).'),
-          'filter[keyword_count][from]': z
+          'filter.keyword_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum number of words in the keyword.'),
-          'filter[keyword_count][to]': z
+          'filter.keyword_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum number of words in the keyword.'),
-          'filter[characters_count][from]': z
+          'filter.characters_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum character length of the keyword.'),
-          'filter[characters_count][to]': z
+          'filter.characters_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum character length of the keyword.'),
-          'filter[serp_features]': z
+          'filter.serp_features': z
             .string()
             .optional()
             .refine(

--- a/src/tools/keywords/keywords-similar.ts
+++ b/src/tools/keywords/keywords-similar.ts
@@ -49,71 +49,71 @@ export class KeywordsSimilar extends BaseTool {
             .optional()
             .default(false)
             .describe('Whether to include historical search volume trend data in the response.'),
-          'filter[volume][from]': z
+          'filter.volume.from': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Minimum monthly search volume.'),
-          'filter[volume][to]': z
+          'filter.volume.to': z
             .number()
             .int()
             .min(0)
             .optional()
             .describe('Maximum monthly search volume.'),
-          'filter[difficulty][from]': z
+          'filter.difficulty.from': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Minimum keyword difficulty score (0-100).'),
-          'filter[difficulty][to]': z
+          'filter.difficulty.to': z
             .number()
             .int()
             .min(0)
             .max(100)
             .optional()
             .describe('Maximum keyword difficulty score (0-100).'),
-          'filter[cpc][from]': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
-          'filter[cpc][to]': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
-          'filter[competition][from]': z
+          'filter.cpc.from': z.number().min(0).optional().describe('Minimum Cost Per Click.'),
+          'filter.cpc.to': z.number().min(0).optional().describe('Maximum Cost Per Click.'),
+          'filter.competition.from': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Minimum competition score (0.0-1.0).'),
-          'filter[competition][to]': z
+          'filter.competition.to': z
             .number()
             .min(0)
             .max(1)
             .optional()
             .describe('Maximum competition score (0.0-1.0).'),
-          'filter[keyword_count][from]': z
+          'filter.keyword_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum number of words in the keyword.'),
-          'filter[keyword_count][to]': z
+          'filter.keyword_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum number of words in the keyword.'),
-          'filter[characters_count][from]': z
+          'filter.characters_count.from': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Minimum character length of the keyword.'),
-          'filter[characters_count][to]': z
+          'filter.characters_count.to': z
             .number()
             .int()
             .min(1)
             .optional()
             .describe('Maximum character length of the keyword.'),
-          'filter[serp_features]': z
+          'filter.serp_features': z
             .string()
             .optional()
             .refine(

--- a/src/validation-partials/json-filters-partials.ts
+++ b/src/validation-partials/json-filters-partials.ts
@@ -26,50 +26,50 @@ export const FilterGroupRefineCallback = (input: string | undefined) => {
 };
 
 export const AISearchFilterObject = {
-  'filter[volume][from]': z
+  'filter.volume.from': z
     .number()
     .int()
     .min(0)
     .optional()
     .describe('Specifies the minimum volume of searches to be included in the results.'),
-  'filter[volume][to]': z
+  'filter.volume.to': z
     .number()
     .int()
     .min(1)
     .optional()
     .describe('Specifies the maximum volume of searches to be included in the results.'),
-  'filter[keyword_count][from]': z
+  'filter.keyword_count.from': z
     .number()
     .int()
     .min(0)
     .optional()
     .describe('Specifies the minimum number of words in prompts.'),
-  'filter[keyword_count][to]': z
+  'filter.keyword_count.to': z
     .number()
     .int()
     .min(1)
     .optional()
     .describe('Specifies the maximum number of words in prompts.'),
-  'filter[characters_count][from]': z
+  'filter.characters_count.from': z
     .number()
     .int()
     .min(0)
     .optional()
     .describe('Specifies the minimum prompt length in characters.'),
-  'filter[characters_count][to]': z
+  'filter.characters_count.to': z
     .number()
     .int()
     .min(1)
     .optional()
     .describe('Specifies the maximum prompt length in characters.'),
-  'filter[multi_keyword_included]': z
+  'filter.multi_keyword_included': z
     .string()
     .optional()
     .describe(
       `A URL-encoded JSON string specifying keywords that must be present in the prompt. For example: filter[multi_keyword_included]=${ExampleJsonFilter}`,
     )
     .refine(FilterGroupRefineCallback, { message: InvalidFilterMessage }),
-  'filter[multi_keyword_excluded]': z
+  'filter.multi_keyword_excluded': z
     .string()
     .optional()
     .describe(


### PR DESCRIPTION
## Problem

SE Ranking MCP server uses bracket notation in property names (e.g., `filter[volume][from]`) which violates Claude's API schema requirements. Property names must match `^[a-zA-Z0-9_.-]{1,64}$` (no brackets allowed).

This causes 400 errors when loading the MCP server in Claude Code/Desktop:

```
API Error: 400
{"type":"error","error":{"type":"invalid_request_error","message":"tools.105.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}'"}}
```

## Solution

### 1. Schema Layer
Replaced bracket notation with DOT notation (Claude-compliant):
- `filter[volume][from]` → `filter.volume.from`
- `filter[keyword_count][from]` → `filter.keyword_count.from`
- `filter[multi_keyword_excluded]` → `filter.multi_keyword_excluded`

### 2. API Layer  
Added transformation layer in `base-tool.ts` to convert DOT → brackets at runtime:

\`\`\`typescript
const apiKey = key.replace(/^filter\.([^.]+)\.([^.]+)$/, 'filter[$1][$2]')
                  .replace(/^filter\.([^.]+)$/, 'filter[$1]');
\`\`\`

This preserves SE Ranking API compatibility while satisfying Claude's schema requirements.

## Edge Cases Handled

Filters with underscores in field names work correctly:

| Schema Property | Transformed to API | Status |
|----------------|-------------------|--------|
| `filter.keyword_count.from` | `filter[keyword_count][from]` | ✅ Tested |
| `filter.characters_count.to` | `filter[characters_count][to]` | ✅ Tested |
| `filter.multi_keyword_excluded` | `filter[multi_keyword_excluded]` | ✅ Tested |

**Why DOT notation:** Using dots as delimiters (instead of underscores) allows the regex pattern `[^.]+` to correctly capture field names containing underscores as single units.

## Testing

All filter types validated end-to-end:

### Test 1: Simple Filter
```javascript
keywordsRelated({
  keyword: "automation",
  "filter.volume.from": 1000,
  "filter.volume.to": 5000
})
```
**Result:** ✅ 27 keywords returned, all volumes 1000-5000

### Test 2: Edge Case (keyword_count)
```javascript
domainKeywords({
  domain: "ahrefs.com",
  "filter.keyword_count.from": 2,
  "filter.keyword_count.to": 3
})
```
**Result:** ✅ All results are 2-3 word phrases

### Test 3: Edge Case (characters_count)
```javascript
keywordsSimilar({
  keyword: "seo",
  "filter.characters_count.from": 10,
  "filter.characters_count.to": 20
})
```
**Result:** ✅ All results are 10-20 characters

### Test 4: Multi-Filter
```javascript
keywordsRelated({
  keyword: "seo tools",
  "filter.volume.from": 3000,
  "filter.volume.to": 8000,
  "filter.difficulty.to": 45
})
```
**Result:** ✅ All results match ALL criteria

**Success rate:** 4/4 tests (100%)

## Files Modified

- `src/tools/base-tool.ts` - Added DOT → bracket transformation layer
- `src/tools/domain/domain-keywords.ts` - Schema property renames
- `src/tools/keywords/keywords-longtail.ts` - Schema property renames
- `src/tools/keywords/keywords-questions.ts` - Schema property renames
- `src/tools/keywords/keywords-related.ts` - Schema property renames
- `src/tools/keywords/keywords-similar.ts` - Schema property renames
- `src/validation-partials/json-filters-partials.ts` - Schema property renames

**Total:** 7 files, 95 insertions(+), 81 deletions(-)

## Impact

Enables SE Ranking MCP server to work with Claude Code and Claude Desktop without schema validation errors.