### PR TITLE
feat: add missing params to multiple Data API tools

### DIFF
--- a/src/tools/data/backlinks/backlinks-export-status.ts
+++ b/src/tools/data/backlinks/backlinks-export-status.ts
@@ -16,6 +16,7 @@ export class GetBacklinksExportStatus extends BaseTool {
             .string()
             .min(1, 'task_id is required')
             .describe('The task ID returned from the exportBacklinksData method (e.g., "1_878619").'),
+          output: z.enum(['json', 'xml']).optional().describe('Output format for the export status response.'),
         },
       },
       async (params) => this.makeGetRequest('/v1/backlinks/export/status', params),

--- a/src/tools/data/backlinks/backlinks-export.ts
+++ b/src/tools/data/backlinks/backlinks-export.ts
@@ -14,6 +14,7 @@ export class ExportBacklinksData extends BaseTool {
         inputSchema: {
           target: z.string().describe('Aim of the request: root domain, host, or URL.'),
           mode: z.enum(['domain', 'host', 'url']).optional().default('host'),
+          output: z.enum(['json', 'xml']).optional().describe('Output format for the export.'),
         },
       },
       async (params) => this.makeGetRequest('/v1/backlinks/export', params),

--- a/src/tools/data/domain/domain-competitors.ts
+++ b/src/tools/data/domain/domain-competitors.ts
@@ -20,6 +20,10 @@ export class GetDomainCompetitors extends BaseTool {
             .string()
             .min(1, 'domain is required')
             .describe('The primary domain for which to find competitors.'),
+          url: z
+            .string()
+            .optional()
+            .describe('A specific URL to find competitors for, instead of the entire domain.'),
           type: z
             .enum(['organic', 'adv'])
             .optional()

--- a/src/tools/data/domain/domain-overview-worldwide.ts
+++ b/src/tools/data/domain/domain-overview-worldwide.ts
@@ -35,6 +35,10 @@ export class GetDomainOverviewWorldwide extends BaseTool {
             .describe(
               'A comma-separated list specifying which data fields or categories to include in the response. This allows for tailoring the response to only the needed information.',
             ),
+          with_subdomains: z
+            .boolean()
+            .optional()
+            .describe('Whether to include subdomain data in the results.'),
           show_zones_list: z
             .number()
             .int()

--- a/src/tools/data/serp/serp-get-locations.ts
+++ b/src/tools/data/serp/serp-get-locations.ts
@@ -19,6 +19,10 @@ export class GetSerpLocations extends BaseTool {
             .describe(
               'Alpha-2 country code for the regional prompt database (e.g., us for United States results).',
             ),
+          include: z
+            .string()
+            .optional()
+            .describe('Additional data to include in the response. Can be set to "google_ads_location_id".'),
         },
       },
       async (params) => this.makeGetRequest('/v1/serp/classic/locations', params),

--- a/src/tools/data/serp/serp-get-results.ts
+++ b/src/tools/data/serp/serp-get-results.ts
@@ -36,6 +36,12 @@ export class GetSerpResults extends BaseTool {
             .array(z.string().min(1, 'query is empty').max(1000, 'too many queries'))
             .describe('List of queries'),
           tag: z.string().max(255, 'tag is too long (max 255 chars)').optional().describe('Tag'),
+          pingback_url: z
+            .string()
+            .optional()
+            .describe(
+              'URL to receive a pingback when the task is complete. Supports $id and $tag placeholders that will be substituted with the task ID and tag (e.g., "https://example.com/callback?id=$id&user_tag=$tag").',
+            ),
           poll_interval_ms: z
             .number()
             .int()
@@ -66,6 +72,7 @@ export class GetSerpResults extends BaseTool {
           location_id: number;
           query: string[];
           tag?: string;
+          pingback_url?: string;
           poll_interval_ms: number;
           max_wait_ms: number;
           result_type: 'standard' | 'advanced';
@@ -79,6 +86,7 @@ export class GetSerpResults extends BaseTool {
           location_id,
           query,
           tag,
+          pingback_url,
           poll_interval_ms,
           max_wait_ms,
           result_type,
@@ -112,6 +120,7 @@ export class GetSerpResults extends BaseTool {
           query,
         };
         if (tag) form.tag = tag;
+        if (pingback_url) form.pingback_url = pingback_url;
 
         const tasks = await this.addSerpTask(form);
 

--- a/src/tools/data/website-audit/get-issues-by-url.ts
+++ b/src/tools/data/website-audit/get-issues-by-url.ts
@@ -22,6 +22,8 @@ export class GetIssuesByUrl extends BaseTool {
             .string()
             .optional()
             .describe('Full page URL. Either url or url_id must be provided.'),
+          limit: z.number().int().positive().optional().describe('Maximum number of results to return.'),
+          offset: z.number().int().min(0).optional().describe('Number of results to skip for pagination.'),
         },
       },
       async (params) => this.makeGetRequest('/v1/site-audit/audits/issues', params),


### PR DESCRIPTION
## Summary
- **backlinks/export & export/status**: add `output` param (`json`/`xml`)
- **domain/overview/worldwide**: add `with_subdomains` param
- **domain/competitors**: add `url` param
- **serp/classic/locations**: add `include` param (`google_ads_location_id`)
- **serp/classic/tasks**: add `pingback_url` param with `$id`/`$tag` substitution
- **site-audit/audits/issues**: add `limit` and `offset` params

## Test plan
- [ ] `npm run build` passes
- [ ] Verify each new param is accepted by the SE Ranking API
- [ ] Run E2E tests with valid tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)